### PR TITLE
Remove serde dependency and use lum_libs::serde as serde crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,10 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "lum_log"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "lum_libs",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lum_log"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Torben Schweren"]
 edition = "2024"
 rust-version = "1.85.0"
@@ -21,8 +21,5 @@ debug = true
 opt-level = 0
 lto = false
 
-# serde has to be a dependency to use the Serialize and Deserialize derive macros.
-# We are still using the implementation from lum_libs, but the macro depends on the serde crate to be present.
 [dependencies]
 lum_libs = "0.2.0"
-serde = { version = "1.0.218", features = ["derive"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ use lum_libs::{
 /// This is used by the [`setup`](crate::setup) function and the [`Builder`](crate::Builder) to set up the logger.
 /// The idea is to implement `AsRef<Config>` for your own configuration type, and then use it to set up the logger.
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(crate = "lum_libs::serde")]
 pub struct Config {
     pub colors: HashMap<LevelFilter, String>,
     pub min_log_level: LevelFilter,


### PR DESCRIPTION
This pull request removes the serde dependency from the project and instead uses the re-exported serde from lum_libs.

Version update:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3): Updated the package version from `0.2.0` to `0.2.1`.

Dependency management:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L24-L28): Removed the `serde` dependency, which was previously required for the `Serialize` and `Deserialize` derive macros.
* [`src/config.rs`](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR12): Added a custom `serde` crate path to the `Config` struct to use the re-exported serde from `lum_libs`.