### PR TITLE
fix: macro depending on lum_lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "lum_log"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "lum_libs",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lum_log"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Torben Schweren"]
 edition = "2024"
 rust-version = "1.85.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,3 +7,4 @@ pub mod macros;
 pub use builder::Builder;
 pub use config::Config;
 pub use logger::{is_set_up, setup};
+pub use lum_libs::log;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -4,7 +4,7 @@
 macro_rules! error {
     ($($arg:tt)*) => {
         if $crate::is_set_up() {
-            lum_libs::log::error!($($arg)*);
+            $crate::log::error!($($arg)*);
         } else {
             eprintln!($($arg)*);
         }
@@ -17,7 +17,7 @@ macro_rules! error {
 macro_rules! warn {
     ($($arg:tt)*) => {
         if $crate::is_set_up() {
-            lum_libs::log::warn!($($arg)*);
+            $crate::log::warn!($($arg)*);
         } else {
             println!($($arg)*);
         }
@@ -30,7 +30,7 @@ macro_rules! warn {
 macro_rules! info {
     ($($arg:tt)*) => {
         if $crate::is_set_up() {
-            lum_libs::log::info!($($arg)*);
+            $crate::log::info!($($arg)*);
         } else {
             println!($($arg)*);
         }
@@ -43,7 +43,7 @@ macro_rules! info {
 macro_rules! debug {
     ($($arg:tt)*) => {
         if $crate::is_set_up() {
-            lum_libs::log::debug!($($arg)*);
+            $crate::log::debug!($($arg)*);
         } else {
             println!($($arg)*);
         }
@@ -56,7 +56,7 @@ macro_rules! debug {
 macro_rules! trace {
     ($($arg:tt)*) => {
         if $crate::is_set_up() {
-            lum_libs::log::trace!($($arg)*);
+            $crate::log::trace!($($arg)*);
         } else {
             println!($($arg)*);
         }


### PR DESCRIPTION
The macro was depending on lum_libs. As macros are evaluated before the consumer of this crate compiles, the consumer had to have lum_libs installed. Now lum_log re-exports its own lum_libs::log and references that.