### PR TITLE
add: ConfigBuilderError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! Furthermore, it provides logging macros that fall back to stdout/stderr if the logger is not set up yet.
 
 /// Defines the [`ConfigBuilder`] for building log4rs configurations.
-pub mod config;
+pub mod builder;
 /// Defines some defaults that help setting up logging.
 pub mod default;
 /// Defines functions to set up the logger.
@@ -13,7 +13,8 @@ pub mod macros;
 
 /// Re-exports of external crates.
 pub use lum_libs::log;
+pub use lum_libs::log4rs;
 
 // Re-exports of internal modules.
-pub use config::ConfigBuilder;
+pub use builder::ConfigBuilder;
 pub use logger::{is_set_up, setup};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,5 +16,5 @@ pub use lum_libs::log;
 pub use lum_libs::log4rs;
 
 // Re-exports of internal modules.
-pub use builder::ConfigBuilder;
+pub use builder::{ConfigBuilder, ConfigBuilderError};
 pub use logger::{is_set_up, setup};


### PR DESCRIPTION
This adds a ConfigBuilderError enum that wraps possible errors happening during config building. This way, a user has to handle only one error type instead of multiple and thus does not need to depend on log4rs themselves.